### PR TITLE
add dot separator for obj name

### DIFF
--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -204,7 +204,7 @@ func TestBody(t *testing.T) {
 		Description: "the description",
 		Required:    true,
 		Schema: &swag.Schema{
-			Ref:       "#/definitions/endpointModel",
+			Ref:       "#/definitions/endpoint.Model",
 			Prototype: reflect.TypeOf(Model{}),
 		},
 	}
@@ -223,7 +223,7 @@ func TestResponse(t *testing.T) {
 	expected := swag.Response{
 		Description: "successful",
 		Schema: &swag.Schema{
-			Ref:       "#/definitions/endpointModel",
+			Ref:       "#/definitions/endpoint.Model",
 			Prototype: Model{},
 		},
 	}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -58,7 +58,7 @@ type Empty struct {
 
 func TestDefine(t *testing.T) {
 	v := define(Pet{})
-	obj, ok := v["swagPet"]
+	obj, ok := v["swag.Pet"]
 	assert.True(t, ok)
 	assert.False(t, obj.IsArray)
 	assert.Equal(t, 17, len(obj.Properties))
@@ -68,7 +68,7 @@ func TestDefine(t *testing.T) {
 	assert.Nil(t, err)
 	err = json.NewDecoder(bytes.NewReader(data)).Decode(&content)
 	assert.Nil(t, err)
-	expected := content["swagPet"]
+	expected := content["swag.Pet"]
 
 	assert.Equal(t, expected.IsArray, obj.IsArray, "expected IsArray to match")
 	assert.Equal(t, expected.Type, obj.Type, "expected Type to match")
@@ -130,7 +130,7 @@ func TestNotStructDefine(t *testing.T) {
 
 func TestHonorJsonIgnore(t *testing.T) {
 	v := define(Empty{})
-	obj, ok := v["swagEmpty"]
+	obj, ok := v["swag.Empty"]
 	assert.True(t, ok)
 	assert.False(t, obj.IsArray)
 	assert.Equal(t, 0, len(obj.Properties), "expected zero exposed properties")

--- a/testdata/pet.json
+++ b/testdata/pet.json
@@ -1,5 +1,5 @@
 {
-  "swagPerson": {
+  "swag.Person": {
     "type": "object",
     "properties": {
       "First": {
@@ -15,7 +15,7 @@
       }
     }
   },
-  "swagPet": {
+  "swag.Pet": {
     "type": "object",
     "required": [
       "pointer"
@@ -85,23 +85,23 @@
         "example": "b"
       },
       "friend": {
-        "$ref": "#/definitions/swagPerson",
+        "$ref": "#/definitions/swag.Person",
         "description": "description short expression"
       },
       "friends": {
         "type": "array",
         "description": "long desc",
         "items": {
-          "$ref": "#/definitions/swagPerson"
+          "$ref": "#/definitions/swag.Person"
         }
       },
       "pointer": {
-        "$ref": "#/definitions/swagPerson"
+        "$ref": "#/definitions/swag.Person"
       },
       "pointers": {
         "type": "array",
         "items": {
-          "$ref": "#/definitions/swagPerson"
+          "$ref": "#/definitions/swag.Person"
         }
       }
     }

--- a/util.go
+++ b/util.go
@@ -69,6 +69,6 @@ func makeName(t reflect.Type) string {
 		ptr := reflect2.PtrOf(t)
 		name = "ptr" + strconv.FormatUint(uint64(uintptr(ptr)), 10)
 	}
-	full := filepath.Base(t.PkgPath()) + name
+	full := filepath.Base(t.PkgPath()) + "." + name
 	return strings.Replace(full, "-", "_", -1)
 }

--- a/util.go
+++ b/util.go
@@ -69,6 +69,10 @@ func makeName(t reflect.Type) string {
 		ptr := reflect2.PtrOf(t)
 		name = "ptr" + strconv.FormatUint(uint64(uintptr(ptr)), 10)
 	}
-	full := filepath.Base(t.PkgPath()) + "." + name
-	return strings.Replace(full, "-", "_", -1)
+	pkgPath := filepath.Base(t.PkgPath())
+	if pkgPath != "." {
+		pkgPath += "."
+	}
+	fullName := pkgPath + name
+	return strings.Replace(fullName, "-", "_", -1)
 }


### PR DESCRIPTION
The object name uses a dot separator to separate the package name and the struct name, which can make the whole name look clearer.
e.g. `typesUser` => `types.User`