### PR TITLE
fix make schema name to support generics

### DIFF
--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -212,7 +212,7 @@ func TestBodyR(t *testing.T) {
 		Name:     "body",
 		Required: true,
 		Schema: &swag.Schema{
-			Ref:       "#/definitions/endpoint.Model",
+			Ref:       "#/definitions/github.com_zc2638_swag_endpoint.Model",
 			Prototype: reflect.TypeOf(Model{}),
 		},
 	}
@@ -234,7 +234,7 @@ func TestBody(t *testing.T) {
 		Description: "the description",
 		Required:    true,
 		Schema: &swag.Schema{
-			Ref:       "#/definitions/endpoint.Model",
+			Ref:       "#/definitions/github.com_zc2638_swag_endpoint.Model",
 			Prototype: reflect.TypeOf(Model{}),
 		},
 	}
@@ -253,7 +253,7 @@ func TestResponse(t *testing.T) {
 	expected := swag.Response{
 		Description: "successful",
 		Schema: &swag.Schema{
-			Ref:       "#/definitions/endpoint.Model",
+			Ref:       "#/definitions/github.com_zc2638_swag_endpoint.Model",
 			Prototype: Model{},
 		},
 	}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -58,7 +58,7 @@ type Empty struct {
 
 func TestDefine(t *testing.T) {
 	v := define(Pet{})
-	obj, ok := v["swag.Pet"]
+	obj, ok := v["github.com_zc2638_swag.Pet"]
 	assert.True(t, ok)
 	assert.False(t, obj.IsArray)
 	assert.Equal(t, 17, len(obj.Properties))
@@ -68,7 +68,7 @@ func TestDefine(t *testing.T) {
 	assert.Nil(t, err)
 	err = json.NewDecoder(bytes.NewReader(data)).Decode(&content)
 	assert.Nil(t, err)
-	expected := content["swag.Pet"]
+	expected := content["github.com_zc2638_swag.Pet"]
 
 	assert.Equal(t, expected.IsArray, obj.IsArray, "expected IsArray to match")
 	assert.Equal(t, expected.Type, obj.Type, "expected Type to match")
@@ -130,7 +130,7 @@ func TestNotStructDefine(t *testing.T) {
 
 func TestHonorJsonIgnore(t *testing.T) {
 	v := define(Empty{})
-	obj, ok := v["swag.Empty"]
+	obj, ok := v["github.com_zc2638_swag.Empty"]
 	assert.True(t, ok)
 	assert.False(t, obj.IsArray)
 	assert.Equal(t, 0, len(obj.Properties), "expected zero exposed properties")

--- a/testdata/pet.json
+++ b/testdata/pet.json
@@ -1,5 +1,5 @@
 {
-  "swag.Person": {
+  "github.com_zc2638_swag.Person": {
     "type": "object",
     "properties": {
       "First": {
@@ -15,7 +15,7 @@
       }
     }
   },
-  "swag.Pet": {
+  "github.com_zc2638_swag.Pet": {
     "type": "object",
     "required": [
       "pointer"
@@ -85,23 +85,23 @@
         "example": "b"
       },
       "friend": {
-        "$ref": "#/definitions/swag.Person",
+        "$ref": "#/definitions/github.com_zc2638_swag.Person",
         "description": "description short expression"
       },
       "friends": {
         "type": "array",
         "description": "long desc",
         "items": {
-          "$ref": "#/definitions/swag.Person"
+          "$ref": "#/definitions/github.com_zc2638_swag.Person"
         }
       },
       "pointer": {
-        "$ref": "#/definitions/swag.Person"
+        "$ref": "#/definitions/github.com_zc2638_swag.Person"
       },
       "pointers": {
         "type": "array",
         "items": {
-          "$ref": "#/definitions/swag.Person"
+          "$ref": "#/definitions/github.com_zc2638_swag.Person"
         }
       }
     }

--- a/util.go
+++ b/util.go
@@ -16,7 +16,6 @@ package swag
 
 import (
 	"fmt"
-	"path"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -68,10 +67,11 @@ func makeName(t reflect.Type) string {
 		ptr := reflect2.PtrOf(t)
 		name = "ptr" + strconv.FormatUint(uint64(uintptr(ptr)), 10)
 	}
-	pkgPath := path.Base(t.PkgPath())
+	pkgPath := t.PkgPath()
 	if pkgPath != "." {
 		pkgPath += "."
 	}
 	fullName := pkgPath + name
-	return strings.Replace(fullName, "-", "_", -1)
+	fullName = strings.ReplaceAll(fullName, "/", "_")
+	return strings.ReplaceAll(fullName, "-", "_")
 }


### PR DESCRIPTION
When versions greater than `1.18` support generics, `makeName` will cause a reference exception.

`github.com/zc2638/swag/option/option.go`
```go
type Test struct {
    Name string `json:"name"`
}
```

`github.com/zc2638/swag/endpoint/endpoint.go`
```go
type List[T any] struct {
    Items []T `json:"items"`
}
```

The above will be parsed by `makeName` as `endpoint.List[github.com/zc2638/swag/option.Test]` and `option.Test`.

Now use the full `pkgPath` and remove the `/` special character, 
will be parsed as `github.com_zc2638_swag_endpoint.List[github.com_zc2638_swag_option.Test]` and `github.com_zc2638_swag_option.Test`.

This will work fine.