### PR TITLE
Update go.mod to retract the v1.14.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-retract v0.1.0
-
-retract v1.2.0
-
-// this is an incorrect release
-retract v1.14.0
+retract (
+    v0.1.0
+    v1.2.0
+    v1.14.0 // incorrect tag
+)

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 )
 
 retract (
-    v0.1.0
-    v1.2.0
-    v1.14.0 // incorrect tag
+        v0.1.0
+        v1.2.0
+        v1.14.0 // incorrect tag
 )


### PR DESCRIPTION
The Go Modules References still shows the v1.14.0 as the latest version, so the retract directive did not work.

➡ https://pkg.go.dev/github.com/zc2638/swag?tab=versions

This is disturbing, getting the latest version with this command would retrieve the v1.14.0 instead of the v.1.6.0:
`go get github.com/zc2638/swag@latest`

Some of my students and myself spent an hour figuring why the library was not working before realizing we retrieved an incorrect version.

Maybe grouping the retract directives would work ?